### PR TITLE
fix: cache multiple image particles to prevent tons of network calls

### DIFF
--- a/src/factories/particle.js
+++ b/src/factories/particle.js
@@ -15,7 +15,7 @@ import {
  */
 export default class ParticleFactory {
   constructor() {
-    this.cachedImage = null;
+    this.cachedImageList = {};
   }
 
   /**
@@ -35,11 +35,10 @@ export default class ParticleFactory {
    *   The path to the image.
    */
   getImageElement(imgSource) {
-    if (!this.cachedImage || imgSource !== this.cachedImage.getAttribute('src')) {
-      this.cachedImage = this.createImageElement(imgSource);
+    if (!this.cachedImageList[imgSource]) {
+      this.cachedImageList[imgSource] = this.createImageElement(imgSource);
     }
-
-    return this.cachedImage;
+    return this.cachedImageList[imgSource];
   }
 
   /**

--- a/tests/specs/factories/particle.spec.js
+++ b/tests/specs/factories/particle.spec.js
@@ -180,7 +180,7 @@ describe('Particle factory', () => {
       const cachedImage = document.createElement('img');
       cachedImage.setAttribute('src', source);
 
-      factory.cachedImage = cachedImage;
+      factory.cachedImageList[source] = cachedImage;
       factory.createImageElement = jest.fn();
 
       const image = factory.getImageElement(source);
@@ -192,28 +192,29 @@ describe('Particle factory', () => {
     it('creates and caches an image if nothing cached', () => {
       const source = '/path/to/img.jpg';
 
-      factory.cachedImage = null;
+      factory.cachedImageList = {};
       factory.createImageElement = jest.fn(() => 'mock-image');
 
       const image = factory.getImageElement(source);
 
       expect(image).toEqual('mock-image');
-      expect(factory.cachedImage).toEqual('mock-image');
+      expect(factory.cachedImageList[source]).toEqual('mock-image');
       expect(factory.createImageElement).toHaveBeenCalledWith(source);
     });
 
     it('creates and caches an image if the src differs', () => {
       const source = '/path/to/img.jpg';
+      const cachedSource = '/some/other/img.jpg';
       const cachedImage = document.createElement('img');
-      cachedImage.setAttribute('src', '/some/other/img.jpg');
+      cachedImage.setAttribute('src', cachedSource);
 
-      factory.cachedImage = cachedImage;
+      factory.cachedImageList = { cachedSource: cachedImage };
       factory.createImageElement = jest.fn(() => 'mock-image');
 
       const image = factory.getImageElement(source);
 
       expect(image).toEqual('mock-image');
-      expect(factory.cachedImage).toEqual('mock-image');
+      expect(factory.cachedImageList[source]).toEqual('mock-image');
       expect(factory.createImageElement).toHaveBeenCalledWith(source);
     });
   });


### PR DESCRIPTION
Problem:
A recent project needed to use 6 different images as particles. I found out the particle factory was making an image request for every new particle generated due to the hundreds of network calls that would show up after running for a few minutes.

Solution:
This pr caches newly created images by their url string. This prevents images from being re-requested once loaded.