### PR TITLE
Support for passing canvas element by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,17 @@ $confetti.start({
 
 #### Custom canvas:
 
+##### By id:
 ``` js
 $confetti.start({
   canvasId: 'my-custom-canvas',
+});
+```
+
+##### By element reference:
+``` js
+$confetti.start({
+  canvasElement: document.getElementById('my-custom-canvas'),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The following options can be passed to `$confetti.start()` or `$confetti.update(
 | defaultDropRate   | Number | The default speed at which the particles fall.                            | 10        |
 | defaultColors     | Array  | The default particle colors.                                              | ['DodgerBlue', 'OliveDrab', 'Gold', 'pink', 'SlateBlue', 'lightblue', 'Violet', 'PaleGreen', 'SteelBlue', 'SandyBrown', 'Chocolate', 'Crimson'] |
 | canvasId          | String | The ID for a custom canvas element (the default is to append a canvas to the `<body>` element).     | null |
+| canvasElement     | HTMLCanvasElement | The canvas element.     | null |
 | particlesPerFrame | Number | The number of particles to drop per animation frame.                      | 2         |
 
 The following options can be passed to each item in `particles`:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dev": "webpack --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "demo": "http-server ./dist -c-1",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -6,18 +6,29 @@ export default class Canvas {
    * Initialise.
    * @param {string} [canvasId]
    *   An optional CSS ID pointing to a canvas to override the default.
+   * @param {HTMLCanvasElement} [canvasId]
+   *   An optional HTMLCanvasElement to override the default.
    */
-  constructor(canvasId) {
+  constructor(canvasId, canvasElement) {
     const defaultCanvasId = 'confetti-canvas';
-    const customCanvas = document.getElementById(canvasId);
 
-    this.isDefault = canvasId === null || typeof canvasId === 'undefined';
+    if (canvasElement) {
+      if (canvasElement instanceof HTMLCanvasElement) {
+        this.canvas = canvasElement;
+      } else {
+        throw new Error('Element is not a valid HTMLCanvasElement');
+      }
+    } else {
+      const customCanvas = document.getElementById(canvasId);
 
-    if (!this.isDefault && !customCanvas) {
-      throw new Error(`No element found with ID "${canvasId}"`);
+      this.isDefault = canvasId === null || typeof canvasId === 'undefined';
+
+      if (!this.isDefault && !customCanvas) {
+        throw new Error(`No element found with ID "${canvasId}"`);
+      }
+
+      this.canvas = customCanvas || Canvas.createDefaultCanvas(defaultCanvasId);
     }
-
-    this.canvas = customCanvas || Canvas.createDefaultCanvas(defaultCanvasId);
 
     if (!(this.canvas instanceof HTMLCanvasElement)) {
       throw new Error(`Element with ID "${defaultCanvasId}" is not a valid HTMLCanvasElement`);

--- a/src/confetti.js
+++ b/src/confetti.js
@@ -64,8 +64,8 @@ export default class Confetti {
    *   The particle options.
    */
   start(opts = {}) {
-    if (!this.canvas || opts.canvasId !== this.canvasId) {
-      this.canvas = new Canvas(opts.canvasId);
+    if (!this.canvas || opts.canvasId !== this.canvasId || opts.canvasElement) {
+      this.canvas = new Canvas(opts.canvasId, opts.canvasElement);
       this.canvasId = opts.canvasId;
     }
 

--- a/tests/specs/canvas.spec.js
+++ b/tests/specs/canvas.spec.js
@@ -7,6 +7,25 @@ describe('Canvas', () => {
     defaultCanvas = new Canvas();
   });
 
+  describe('use existing canvas', () => {
+    it('canvas by element reference', () => {
+      const canvasElm = document.createElement('canvas');
+      canvasElm.id = 'page-canvas';
+      const canvas = new Canvas(null, canvasElm);
+
+      expect(canvas.canvas.id).toEqual(canvasElm.id);
+    });
+
+    it('should throw an error when invalid canvas element is passed', () => {
+      const divElm = document.createElement('div');
+      divElm.id = 'page-canvas';
+
+      expect(() => {
+        new Canvas(null, divElm);
+      }).toThrow('Element is not a valid HTMLCanvasElement');
+    });
+  });
+
   describe('createDefaultCanvas', () => {
     it('creates a canvas with the expected styles', () => {
       const canvas = Canvas.createDefaultCanvas();


### PR DESCRIPTION
Added support to attach confetti to canvas element passed by reference. Useful in the scenario where your canvas element is not part of document directly, for example part of shadow dom.