### PR TITLE
feat: add support for passing canvas element by reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-confetti",
   "description": "A Vue component for dropping confetti.",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "main": "dist/vue-confetti.js",
   "author": "Alex Mendes <alexanderhmendes@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "dev": "webpack --watch",
     "build": "cross-env NODE_ENV=production webpack",
     "demo": "http-server ./dist -c-1",
-    "release": "semantic-release",
-    "prepare": "npm run build"
+    "release": "semantic-release"
   },
   "repository": {
     "type": "git",
@@ -50,7 +49,7 @@
     "http-server": "^0.11.1",
     "husky": "^1.3.1",
     "jest": "^24.1.0",
-    "jest-canvas-mock": "^2.0.0-alpha.3",
+    "jest-canvas-mock": "^2.2.0",
     "jest-mock-random": "^1.0.2",
     "node-sass": "^4.12.0",
     "normalize.css": "^8.0.1",

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -4,35 +4,19 @@
 export default class Canvas {
   /**
    * Initialise.
-   * @param {string} [canvasId]
-   *   An optional CSS ID pointing to a canvas to override the default.
-   * @param {HTMLCanvasElement} [canvasId]
+   * @param {HTMLCanvasElement} [canvasElement]
    *   An optional HTMLCanvasElement to override the default.
    */
-  constructor(canvasId, canvasElement) {
+  constructor(canvasElement) {
     const defaultCanvasId = 'confetti-canvas';
 
-    if (canvasElement) {
-      if (canvasElement instanceof HTMLCanvasElement) {
-        this.canvas = canvasElement;
-      } else {
-        throw new Error('Element is not a valid HTMLCanvasElement');
-      }
-    } else {
-      const customCanvas = document.getElementById(canvasId);
-
-      this.isDefault = canvasId === null || typeof canvasId === 'undefined';
-
-      if (!this.isDefault && !customCanvas) {
-        throw new Error(`No element found with ID "${canvasId}"`);
-      }
-
-      this.canvas = customCanvas || Canvas.createDefaultCanvas(defaultCanvasId);
+    if (canvasElement && !(canvasElement instanceof HTMLCanvasElement)) {
+      throw new Error('Element is not a valid HTMLCanvasElement');
     }
 
-    if (!(this.canvas instanceof HTMLCanvasElement)) {
-      throw new Error(`Element with ID "${defaultCanvasId}" is not a valid HTMLCanvasElement`);
-    }
+    this.isDefault = !canvasElement;
+
+    this.canvas = canvasElement || Canvas.createDefaultCanvas(defaultCanvasId);
 
     this.ctx = this.canvas.getContext('2d');
   }

--- a/src/confetti.js
+++ b/src/confetti.js
@@ -19,7 +19,7 @@ export default class Confetti {
     this.killed = false;
     this.framesSinceDrop = 0;
     this.canvas = null;
-    this.canvasId = null;
+    this.canvasEl = null;
     this.W = 0;
     this.H = 0;
     this.particleManager = null;
@@ -59,14 +59,44 @@ export default class Confetti {
   }
 
   /**
+   * Get a canvas element from the given options.
+   * @param {Object} opts
+   *   The particle options.
+   */
+  getCanvasElementFromOptions(opts) {
+    const { canvasId, canvasElement } = opts;
+    let canvasEl = canvasElement;
+
+    if (canvasElement && !(canvasElement instanceof HTMLCanvasElement)) {
+      throw new Error('Invalid options: canvasElement is not a valid HTMLCanvasElement');
+    }
+
+    if (canvasId && canvasElement) {
+      throw new Error('Invalid options: canvasId and canvasElement are mutually exclusive');
+    }
+
+    if (canvasId && !canvasEl) {
+      canvasEl = document.getElementById(canvasId);
+    }
+
+    if (canvasId && !(canvasEl instanceof HTMLCanvasElement)) {
+      throw new Error(`Invalid options: element with id "${canvasId}" is not a valid HTMLCanvasElement`);
+    }
+
+    return canvasEl;
+  }
+
+  /**
    * Start dropping confetti.
    * @param {Object} opts
    *   The particle options.
    */
   start(opts = {}) {
-    if (!this.canvas || opts.canvasId !== this.canvasId || opts.canvasElement) {
-      this.canvas = new Canvas(opts.canvasId, opts.canvasElement);
-      this.canvasId = opts.canvasId;
+    const canvasEl = this.getCanvasElementFromOptions(opts);
+
+    if (!this.canvas || canvasEl !== this.canvasEl) {
+      this.canvas = new Canvas(canvasEl);
+      this.canvasEl = canvasEl;
     }
 
     if (this.animationId) {
@@ -98,7 +128,9 @@ export default class Confetti {
    * Update the confetti options.
    */
   update(opts) {
-    if (this.canvas && opts.canvasId !== this.canvasId) {
+    const canvasEl = this.getCanvasElementFromOptions(opts);
+
+    if (this.canvas && canvasEl !== this.canvasEl) {
       this.stop();
       this.canvas.clear();
       this.start(opts);

--- a/tests/specs/__snapshots__/confetti.spec.js.snap
+++ b/tests/specs/__snapshots__/confetti.spec.js.snap
@@ -6,7 +6,7 @@ Confetti {
   "W": 0,
   "animationId": null,
   "canvas": null,
-  "canvasId": null,
+  "canvasEl": null,
   "framesSinceDrop": 0,
   "killed": false,
   "particleManager": null,

--- a/tests/specs/canvas.spec.js
+++ b/tests/specs/canvas.spec.js
@@ -7,25 +7,6 @@ describe('Canvas', () => {
     defaultCanvas = new Canvas();
   });
 
-  describe('use existing canvas', () => {
-    it('canvas by element reference', () => {
-      const canvasElm = document.createElement('canvas');
-      canvasElm.id = 'page-canvas';
-      const canvas = new Canvas(null, canvasElm);
-
-      expect(canvas.canvas.id).toEqual(canvasElm.id);
-    });
-
-    it('should throw an error when invalid canvas element is passed', () => {
-      const divElm = document.createElement('div');
-      divElm.id = 'page-canvas';
-
-      expect(() => {
-        new Canvas(null, divElm);
-      }).toThrow('Element is not a valid HTMLCanvasElement');
-    });
-  });
-
   describe('createDefaultCanvas', () => {
     it('creates a canvas with the expected styles', () => {
       const canvas = Canvas.createDefaultCanvas();

--- a/tests/specs/confetti.spec.js
+++ b/tests/specs/confetti.spec.js
@@ -1,6 +1,27 @@
 import Confetti from '../../src/confetti';
 
+expect.extend({
+  toHaveCanvasEvents(canvas) {
+    // eslint-disable-next-line no-underscore-dangle
+    const hasEvents = canvas.getContext('2d').__getEvents().length > 0;
+
+    return {
+      pass: hasEvents,
+      message: () => `Expected canvas to${this.isNot ? ' not ' : ' '}have events`,
+    };
+  },
+});
+
 describe('Confetti', () => {
+  beforeEach(() => {
+    // Mock for a single frame only
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementationOnce(cb => cb());
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame.mockRestore();
+  });
+
   it('is initialised with default settings', () => {
     const confetti = new Confetti();
 
@@ -11,5 +32,89 @@ describe('Confetti', () => {
     const confetti = new Confetti();
 
     expect(() => confetti.start()).not.toThrow();
+  });
+
+  describe('start', () => {
+    it('accepts a canvas by element reference', () => {
+      const confetti = new Confetti();
+      const canvasElement = document.createElement('canvas');
+
+      confetti.start({ canvasElement });
+
+      expect(canvasElement).toHaveCanvasEvents();
+    });
+
+    it('accepts a canvas by ID', () => {
+      const confetti = new Confetti();
+      const canvasElement = document.createElement('canvas');
+
+      canvasElement.id = 'my-canvas';
+      document.body.appendChild(canvasElement);
+
+      confetti.start({ canvasId: 'my-canvas' });
+
+      expect(canvasElement).toHaveCanvasEvents();
+    });
+
+    it('throws if given element is not a canvas', () => {
+      const confetti = new Confetti();
+      const canvasElement = document.createElement('div');
+
+      expect(() => confetti.start({ canvasElement })).toThrow(
+        /.*not a valid HTMLCanvasElement.*/,
+      );
+    });
+
+    it('throws if given ID is not for a canvas', () => {
+      const confetti = new Confetti();
+      const canvasElement = document.createElement('div');
+      canvasElement.id = 'not-a-canvas';
+
+      expect(() => confetti.start({ canvasId: 'not-a-canvas' })).toThrow(
+        /.*not a valid HTMLCanvasElement.*/,
+      );
+    });
+
+    it('throws if both canvas element and id are given', () => {
+      const confetti = new Confetti();
+      const canvasElement = document.createElement('canvas');
+
+      expect(() => confetti.start({ canvasId: 'foo', canvasElement })).toThrow(
+        /.*mutually exclusive.*/,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('restarts if given a new canvas by element reference', () => {
+      const confetti = new Confetti();
+      const canvasElementOne = document.createElement('canvas');
+      const canvasElementTwo = document.createElement('canvas');
+
+      const spy = jest.spyOn(confetti, 'start');
+
+      confetti.start({ canvasElement: canvasElementOne });
+      confetti.update({ canvasElement: canvasElementTwo });
+
+      expect(spy).toHaveBeenCalledWith({ canvasElement: canvasElementTwo });
+    });
+
+    it('restarts if given a new canvas by ID', () => {
+      const confetti = new Confetti();
+      const canvasElementOne = document.createElement('canvas');
+      const canvasElementTwo = document.createElement('canvas');
+
+      const spy = jest.spyOn(confetti, 'start');
+
+      canvasElementOne.id = 'my-canvas-one';
+      canvasElementTwo.id = 'my-canvas-two';
+      document.body.appendChild(canvasElementOne);
+      document.body.appendChild(canvasElementTwo);
+
+      confetti.start({ canvasId: 'my-canvas-one' });
+      confetti.update({ canvasId: 'my-canvas-two' });
+
+      expect(spy).toHaveBeenCalledWith({ canvasId: 'my-canvas-two' });
+    });
   });
 });

--- a/tests/specs/factories/particle.spec.js
+++ b/tests/specs/factories/particle.spec.js
@@ -217,6 +217,17 @@ describe('Particle factory', () => {
       expect(factory.cachedImages[source]).toEqual('mock-image');
       expect(factory.createImageElement).toHaveBeenCalledWith(source);
     });
+
+    it('caches multiple images', () => {
+      const imageA = factory.getImageElement('/img.jpg');
+      const imageB = factory.getImageElement('/another-img.jpg');
+      const imageC = factory.getImageElement('/img.jpg');
+      const imageD = factory.getImageElement('/another-img.jpg');
+
+      expect(imageA).toEqual(imageC);
+      expect(imageB).toEqual(imageD);
+      expect(imageA).not.toEqual(imageB);
+    });
   });
 
   describe('createImageElement', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5263,10 +5263,10 @@ java-properties@^1.0.0:
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
 
-jest-canvas-mock@^2.0.0-alpha.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.1.1.tgz#fc59b16b093620345c7865f34ef1a16940eec784"
-  integrity sha512-FK/xAFYJmMwyY8IpVrpoHq8Od/99Jmc3g6pnmkhFkYQJoq1Y0ZtEZjs80cREKlxjQxcTMvPpoyGLOmt8KLjlSQ==
+jest-canvas-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.2.0.tgz#45fbc58589c6ce9df50dc90bd8adce747cbdada7"
+  integrity sha512-DcJdchb7eWFZkt6pvyceWWnu3lsp5QWbUeXiKgEMhwB3sMm5qHM1GQhDajvJgBeiYpgKcojbzZ53d/nz6tXvJw==
   dependencies:
     cssfontparser "^1.2.1"
     parse-color "^1.0.0"
@@ -7053,7 +7053,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7068,7 +7067,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7087,14 +7085,8 @@ npm@^6.10.3:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
Extends https://github.com/alexandermendes/vue-confetti/pull/49 to add a few more tests and ensure it works for the `update()` method too.