### PR TITLE
fix: clear canvas entirely before starting another run

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -92,19 +92,14 @@ export default class Confetti {
    *   The particle options.
    */
   start(opts = {}) {
+    this.remove(); // clear any previous settings
+
     const canvasEl = this.getCanvasElementFromOptions(opts);
 
-    if (!this.canvas || canvasEl !== this.canvasEl) {
-      this.canvas = new Canvas(canvasEl);
-      this.canvasEl = canvasEl;
-    }
-
-    if (this.animationId) {
-      cancelAnimationFrame(this.animationId); // Cancel any previous loop
-    }
+    this.canvas = new Canvas(canvasEl);
+    this.canvasEl = canvasEl;
 
     this.createParticles(opts);
-    this.canvas.updateDimensions();
     this.setParticlesPerFrame(opts);
     this.animationId = requestAnimationFrame(this.mainLoop.bind(this));
   }
@@ -130,10 +125,10 @@ export default class Confetti {
   update(opts) {
     const canvasEl = this.getCanvasElementFromOptions(opts);
 
+    // Restart if a different canvas is given
     if (this.canvas && canvasEl !== this.canvasEl) {
-      this.stop();
-      this.canvas.clear();
       this.start(opts);
+      return;
     }
 
     this.setParticlesPerFrame(opts);
@@ -149,11 +144,15 @@ export default class Confetti {
    */
   remove() {
     this.stop();
+
     if (this.animationId) {
       cancelAnimationFrame(this.animationId);
     }
 
-    this.canvas.clear();
+    if (this.canvas) {
+      this.canvas.clear();
+    }
+
     this.setDefaults();
   }
 


### PR DESCRIPTION
Ensures the old canvas is wiped entirely to prevent https://github.com/alexandermendes/vue-confetti/issues/36. Really the thing causing it is `this.framesSinceDrop` not being reset to zero, leading to the animation loop thinking it needs to dump a bunch of confetti to catch up. Will follow up with more tests.